### PR TITLE
Reorder runtime dependecies and make dpc runtimes optional

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
+mpich:
+- '4'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
+mpich:
+- '4'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
+mpich:
+- '4'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
+mpich:
+- '4'
 numpy:
 - '2.0'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,9 @@ build:
   - DPCPPROOT
   - DALROOT
   - NO_DIST=1  # [win]
+  ignore_run_exports:
+  - dpcpp_linux-64  # [linux64]
+  # - dpcpp_win-64  # [win]
 
 requirements:
   build:
@@ -42,13 +45,15 @@ requirements:
     - cython
     - jinja2
     - pybind11
-    - numpy {{ numpy }}
-    - impi-devel  # [not win]
+    - numpy
+    - mpich  # [not win]
     # dal-devel pinning depends on the recipe location (repo or feedstock)
     # - dal-devel
     - dal-devel =={{ version }}
   run:
     - python
+    - numpy
+    - scikit-learn
     # dal pinning depends on the recipe location (repo or feedstock)
     # - dal
     - dal =={{ version }}
@@ -56,7 +61,7 @@ requirements:
 test:
   requires:
     - pyyaml
-    - impi_rt  # [not win]
+    - mpich  # [not win]
     # DPC part of sklearnex is optional
     - dpcpp-cpp-rt  # [linux64]
     # TODO: enable data parallel frameworks when they are available on conda-forge
@@ -64,7 +69,6 @@ test:
     # - dpnp
     # next deps are synced with requirements-test.txt
     - pytest
-    - scikit-learn
     - pandas
     - xgboost
     - lightgbm

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # NB: this recipe should be synced between sklearnex repo and feedstocks
 
 {% set name = "scikit-learn-intelex" %}
-{% set buildnumber = 0 %}
+{% set buildnumber = 1 %}
 # version is set manually in feedstocks and through git tag in repo
 {% set version = "2025.0.0" %}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Changes:
- Move scikit-learn and numpy to runtime dependencies
- Make dpc runtimes optional dependency
- Revert MPI to mpich version

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
