### PR TITLE
Add necessary dependencies for MPI tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,20 +47,22 @@ requirements:
     # dal-devel pinning depends on the recipe location (repo or feedstock)
     # - dal-devel
     - dal-devel =={{ version }}
-    - impi-devel  # [not win]
-    - mpi * impi  # [not win]
+    - impi-devel
+    - mpi * impi
   run:
     - python
     - numpy
     - scikit-learn
     - scikit-learn  <1.6  # [py<=39]
     # dal-devel has run_exports on conda-forge, so no need to add it.
-    - mpi * impi  # [not win]
+    - mpi * impi
 
 test:
   requires:
     - pyyaml
-    - mpi * impi  # [not win]
+    - mpi * impi
+    - mpi4py
+    - pytest-mpi
     # DPC part of sklearnex is optional
     - dpcpp-cpp-rt  # [linux64]
     # TODO: enable data parallel frameworks when they are available on conda-forge


### PR DESCRIPTION
Currently, MPI tests are not executing the CI jobs due to missing optional dependencies. This PR adds them in order to execute MPI tests. Since these runners don't have GPUs, it would only execute CPU tests, and only on a single node, but at least will check that the tests run.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
