### PR TITLE
remove sklearn version cap for 2026.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -12,30 +12,45 @@ jobs:
         CONFIG: win_64_python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: D:\\bld\\
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
       win_64_python3.11.____cpython:
         CONFIG: win_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: D:\\bld\\
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
       win_64_python3.12.____cpython:
         CONFIG: win_64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: D:\\bld\\
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
       win_64_python3.13.____cp313:
         CONFIG: win_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: D:\\bld\\
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
       win_64_python3.14.____cp314:
         CONFIG: win_64_python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: D:\\bld\\
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
   timeoutInMinutes: 360
@@ -43,21 +58,20 @@ jobs:
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
-        MINIFORGE_HOME: $(tools_install_dir)
-        CONDA_BLD_PATH: $(build_workspace_dir)
-        PYTHONUNBUFFERED: 1
-        CONFIG: $(CONFIG)
         CI: azure
+        CONFIG: $(CONFIG)
+        CONDA_BLD_PATH: $(build_workspace_dir)
+        MINIFORGE_HOME: $(tools_install_dir)
+        PYTHONUNBUFFERED: 1
+        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
+        UPLOAD_TEMP: $(UPLOAD_TEMP)
         flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
         remote_url: $(Build.Repository.Uri)
         sha: $(Build.SourceVersion)
-        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
-        UPLOAD_TEMP: $(UPLOAD_TEMP)
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,116 +23,137 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpython
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.11.____cpython
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.12.____cpython
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.13.____cp313
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.14.____cp314
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CI: github_actions
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        CI: github_actions
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -145,12 +166,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -58,18 +58,33 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    conda debug \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
     # Drop into an interactive shell
     /bin/bash
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+    conda-build \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --suppress-variables \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # NB: this recipe should be synced between sklearnex repo and feedstocks
 
 {% set name = "scikit-learn-intelex" %}
-{% set buildnumber = 0 %}
+{% set buildnumber = 1 %}
 # version is set manually in feedstocks and through git tag in repo
 {% set version = "2026.1.0" %}
 
@@ -74,8 +74,7 @@ outputs:
       run:
         - python
         - numpy
-        # <1.9 cap is temporary: 2026.0 predates sklearn 1.9 support. Remove for 2026.1.
-        - scikit-learn >=1.0,<1.9
+        - scikit-learn >=1.0
         # dal-devel has run_exports on conda-forge, so no need to add it.
         - mpi * impi  # [not win]
         - packaging  # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,6 +97,7 @@ outputs:
         - array-api-strict
         - array-api-strict <2.4  # [py<312]
         - polars
+        - numpy >=2.2
       source_files:
         - .ci
         - setup.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,7 +92,8 @@ outputs:
         - lightgbm
         - treelite
         - shap
-        - catboost
+        # catboost <1.2.8 is ABI-incompatible with numpy 2.x
+        - catboost >=1.2.8
         - array-api-compat
         - array-api-strict
         - array-api-strict <2.4  # [py<312]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ package:
 source:
   url: https://github.com/uxlfoundation/scikit-learn-intelex/archive/{{ version }}.tar.gz
   sha256: 6b2eb283d1d59ebc2ed4855a9ea07c5c1529728ae4ed7b0f2911551727534eec
+  patches:
+    - patches/0007-xgb-test-backport.patch
 # source:
 #   path: ..
 

--- a/recipe/patches/0007-xgb-test-backport.patch
+++ b/recipe/patches/0007-xgb-test-backport.patch
@@ -1,0 +1,153 @@
+diff --git a/tests/test_model_builders.py b/tests/test_model_builders.py
+index b82b053d..9a3392e8 100644
+--- a/tests/test_model_builders.py
++++ b/tests/test_model_builders.py
+@@ -48,7 +48,11 @@ from sklearn.model_selection import train_test_split
+ 
+ import daal4py as d4p
+ from daal4py.mb import gbt_convertors
+-from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
++from daal4py.sklearn._utils import (
++    _package_check_version,
++    daal_check_version,
++    sklearn_check_version,
++)
+ 
+ try:
+     import catboost as cb
+@@ -592,31 +596,34 @@ def test_xgb_unsupported(from_treelite):
+     with pytest.raises(TypeError):
+         d4p.mb.convert_model(xgb_model)
+ 
+-    xgb_model = xgb.train(
+-        dtrain=xgb.DMatrix(X, y),
+-        num_boost_round=5,
+-        params={
+-            "objective": "reg:squarederror",
+-            "booster": "dart",
+-            "max_depth": 3,
+-            "seed": 123,
+-            "nthread": 1,
+-        },
+-    )
+-    if not from_treelite:
+-        with pytest.raises(TypeError):
+-            d4p.mb.convert_model(xgb_model)
+-    else:
+-        # In this case, TreeLite handles the drop logic on their end in a
+-        # format that is consumable by daal4py.
+-        tl_model = treelite.frontend.from_xgboost(xgb_model)
+-        d4p_model = d4p.mb.convert_model(tl_model)
+-        np.testing.assert_allclose(
+-            d4p_model.predict(X),
+-            treelite.gtil.predict(tl_model, X, pred_margin=True).reshape(-1),
+-            atol=1e-5,
+-            rtol=1e-5,
++    # Note: dart booster in previous versions had a different
++    # structure than regular tree booster.
++    if not _package_check_version(xgb.__version__, "3.3.0"):
++        xgb_model = xgb.train(
++            dtrain=xgb.DMatrix(X, y),
++            num_boost_round=5,
++            params={
++                "objective": "reg:squarederror",
++                "booster": "dart",
++                "max_depth": 3,
++                "seed": 123,
++                "nthread": 1,
++            },
+         )
++        if not from_treelite:
++            with pytest.raises(TypeError):
++                d4p.mb.convert_model(xgb_model)
++        else:
++            # In this case, TreeLite handles the drop logic on their end in a
++            # format that is consumable by daal4py.
++            tl_model = treelite.frontend.from_xgboost(xgb_model)
++            d4p_model = d4p.mb.convert_model(tl_model)
++            np.testing.assert_allclose(
++                d4p_model.predict(X),
++                treelite.gtil.predict(tl_model, X, pred_margin=True).reshape(-1),
++                atol=1e-5,
++                rtol=1e-5,
++            )
+ 
+     xgb_model = xgb.train(
+         dtrain=xgb.DMatrix(X, y),
+@@ -1759,30 +1766,29 @@ def test_sklearn_through_treelite(
+ 
+ 
+ def test_treelite_unsupported():
+-    if sklearn_check_version("1.4"):
+-        X, y = make_classification(
+-            n_samples=10,
+-            n_classes=3,
+-            n_informative=3,
+-            n_redundant=0,
+-            random_state=123,
+-        )
+-        tl_model = treelite.sklearn.import_model(
+-            RandomForestClassifier(n_estimators=3).fit(X, y)
+-        )
+-        with pytest.raises(TypeError):
+-            with warnings.catch_warnings():
+-                warnings.simplefilter("ignore")
+-                d4p_model = d4p.mb.convert_model(tl_model)
++    X, y = make_classification(
++        n_samples=10,
++        n_classes=3,
++        n_informative=3,
++        n_redundant=0,
++        random_state=123,
++    )
++    tl_model = treelite.sklearn.import_model(
++        RandomForestClassifier(n_estimators=3).fit(X, y)
++    )
++    with pytest.raises(TypeError):
++        with warnings.catch_warnings():
++            warnings.simplefilter("ignore")
++            d4p_model = d4p.mb.convert_model(tl_model)
+ 
+-        y_multi = np.c_[(y == 0).reshape((-1, 1)), (y == 1)[::-1].reshape((-1, 1))]
+-        tl_model = treelite.sklearn.import_model(
+-            RandomForestClassifier(n_estimators=3).fit(X, y_multi)
+-        )
+-        with pytest.raises(TypeError):
+-            with warnings.catch_warnings():
+-                warnings.simplefilter("ignore")
+-                d4p_model = d4p.mb.convert_model(tl_model)
++    y_multi = np.c_[(y == 0).reshape((-1, 1)), (y == 1)[::-1].reshape((-1, 1))]
++    tl_model = treelite.sklearn.import_model(
++        RandomForestClassifier(n_estimators=3).fit(X, y_multi)
++    )
++    with pytest.raises(TypeError):
++        with warnings.catch_warnings():
++            warnings.simplefilter("ignore")
++            d4p_model = d4p.mb.convert_model(tl_model)
+ 
+     X, y = make_regression(n_samples=10, n_features=4, random_state=123, n_targets=2)
+     tl_model = treelite.sklearn.import_model(
+@@ -2051,8 +2057,6 @@ def test_gbt_serialization():
+ @pytest.mark.parametrize("n_classes", [2, 3])
+ def test_logreg_builder(fit_intercept, stochastic, n_classes):
+     if stochastic:
+-        if not sklearn_check_version("1.1"):
+-            pytest.skip("Functionality introduced in a later sklearn version.")
+         if n_classes != 2:
+             pytest.skip("Functionality not yet implemented in sklearn.")
+     if stochastic:
+@@ -2188,13 +2192,9 @@ def test_logreg_builder_sequential_calls():
+     )
+     + [
+         # case below might change in the future if sklearn improves their modules
+-        pytest.param(
++        (
+             SGDClassifier(loss="log_loss"),
+             3,
+-            marks=pytest.mark.skipif(
+-                not sklearn_check_version("1.1"),
+-                reason="Requires higher sklearn version.",
+-            ),
+         ),
+         (
+             SGDClassifier(loss="hinge"),


### PR DESCRIPTION
Removes version cap for sklearn, allowing sklearnex 2026.1 to be installed with sklearn 1.9. Bumps version number to rebuild.
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
